### PR TITLE
Add decode_to_slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,10 @@ pub fn decode_to_slice<'a>(data: &[u8], res: &'a mut [u8]) -> Result<&'a mut [u8
 
     impl<'a> Vec<'a> {
         fn try_push(&mut self, x: u8) -> Result<(), DecodeError> {
-            *self.data.get_mut(self.len).ok_or(DecodeError::BufferOverflow)? = x;
+            *self
+                .data
+                .get_mut(self.len)
+                .ok_or(DecodeError::BufferOverflow)? = x;
             self.len += 1;
 
             Ok(())
@@ -200,7 +203,7 @@ pub fn decode_to_slice<'a>(data: &[u8], res: &'a mut [u8]) -> Result<&'a mut [u8
         }
     }
 
-    let mut res = Vec{ data: res, len: 0 };
+    let mut res = Vec { data: res, len: 0 };
 
     let mut data = data.iter().rev().cloned();
     while let Some(x) = data.next() {
@@ -208,7 +211,7 @@ pub fn decode_to_slice<'a>(data: &[u8], res: &'a mut [u8]) -> Result<&'a mut [u8
             0 => return Err(DecodeError::MalformedError),
             0x01..=0x7f => {
                 for i in 0..7 {
-                    if x & (1 << (6-i)) == 0 {
+                    if x & (1 << (6 - i)) == 0 {
                         res.try_push(data.next().ok_or(DecodeError::MalformedError)?)?;
                     } else {
                         res.try_push(0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ trait Buffer {
     fn rev(&mut self);
 }
 
+#[cfg(feature = "std")]
 impl Buffer for Vec<u8> {
     fn try_push(&mut self, x: u8) -> Result<(), DecodeError> {
         Vec::<u8>::push(self, x);


### PR DESCRIPTION
This is more of a feature request/something to point at, than the end result.

I have a use case where I want to communicate between two MCU's over uart. Thus I need both encode *and* decode in a no_std compatible way.